### PR TITLE
Remove the hard-coded layer name in topo.json

### DIFF
--- a/src/air.ls
+++ b/src/air.ls
@@ -147,14 +147,14 @@ path = d3.geo.path!projection proj
 
 ### Draw Taiwan
 draw-taiwan = (countiestopo) ->
+  for layer-name, topo-objects of countiestopo.objects
+    counties = topojson.feature countiestopo, topo-objects
 
-  counties = topojson.feature countiestopo, countiestopo.objects['twCounty2010.geo']
-
-  g.selectAll 'path'
-    .data counties.features
-    .enter!append 'path'
-    .attr 'class', -> \q-9-9
-    .attr 'd', path
+    g.selectAll 'path'
+      .data counties.features
+      .enter!append 'path'
+      .attr 'class', -> \q-9-9
+      .attr 'd', path
 
 ConvertDMSToDD = (days, minutes, seconds) ->
   days = +days


### PR DESCRIPTION
那個 twCounty2010.geo 的 layer name 似乎沒有標準，不同工具可能產生出不同的 layer name。
因此換一種寫法，把所有的 layer 都畫出來，應該是比較通用的處理方式。
