### PR TITLE
Use data mirror instead of epa.gov.tw's API

### DIFF
--- a/src/air.ls
+++ b/src/air.ls
@@ -430,7 +430,8 @@ aqx-csv-url-with-time = (t) ->
   min   = t.substr 10,2
   return "https://raw.githubusercontent.com/g0v-data/mirror-#{year}/master/epa/aqx/#{year}-#{month}-#{day}/#{hour}-#{min}.csv"
 
-draw-all = (_stations, aqx_url = 'http://opendata.epa.gov.tw/ws/Data/AQX/?$orderby=SiteName&$skip=0&$top=1000&format=csv' ) ->
+# original aqx_url: http://opendata.epa.gov.tw/ws/Data/AQX/?$orderby=SiteName&$skip=0&$top=1000&format=csv
+draw-all = (_stations, aqx_url = 'http://g0v-data-mirror.gugod.org/epa/aqx.csv' ) ->
   if location.pathname.match /^\/air/
     stations := for s in _stations
       s.lng = s.TWD97Lon
@@ -504,7 +505,8 @@ else
 if location.pathname.match /^\/air/
   setup-history!
   do
-    forecast <- d3.csv piped 'http://opendata.epa.gov.tw/ws/Data/AQF/?$orderby=AreaName&$skip=0&$top=1000&format=csv'
+    # original url: http://opendata.epa.gov.tw/ws/Data/AQF/?$orderby=AreaName&$skip=0&$top=1000&format=csv
+    forecast <- d3.csv piped 'http://g0v-data-mirror.gugod.org/epa/aqx.csv'
     return unless forecast
     first = forecast[0]
     d3.select \#forecast

--- a/src/air.ls
+++ b/src/air.ls
@@ -478,6 +478,7 @@ zoom = d3.behavior.zoom!
 
 if location.pathname.match /^\/air/
   now = (new Date!).getTime!
+  setup-history!
   countiestopo, stations <- (done) ->
     if localStorage.countiestopo and localStorage.stations
       countiestopo = JSON.parse localStorage.countiestopo
@@ -500,16 +501,3 @@ if location.pathname.match /^\/air/
 else
   stations <- d3.json "/stations.json"
   draw-all stations
-
-
-if location.pathname.match /^\/air/
-  setup-history!
-  do
-    # original url: http://opendata.epa.gov.tw/ws/Data/AQF/?$orderby=AreaName&$skip=0&$top=1000&format=csv
-    forecast <- d3.csv piped 'http://g0v-data-mirror.gugod.org/epa/aqx.csv'
-    return unless forecast
-    first = forecast[0]
-    d3.select \#forecast
-      .text first.Content
-    d3.select \#info-panel
-      .text first.Content


### PR DESCRIPTION
Seems that epa.gov.tw is blocking CORS proxy's IP.

Related conversation: http://logbot.g0v.tw/channel/g0v.tw/2015-12-15#17

However, the data mirror does not return the resulting CSV in the specified order.
(Origial URLs contains `orderby=SiteName` and `orderby= AreaName`)
From the source code I cannot tell why the order matters, and the resulting page in browser looks good to me.

Certainly requires some review & investigation (especially on if the order matters) before merge.