### PR TITLE
Use CORS proxy that is dedicated to env.g0v.tw

### DIFF
--- a/src/air.ls
+++ b/src/air.ls
@@ -354,7 +354,11 @@ update-seven-segment = (value-string) ->
 
 function piped(url)
   url -= /^https?:\/\//
-  return "https://cors-anywhere.herokuapp.com/#url"
+  if (new Date).getUTCHours! < 12
+    return "https://envg0vtw-cors-dayshift.herokuapp.com/#url"
+  else
+    return "https://envg0vtw-cors-nightshift.herokuapp.com/#url"
+
 
 #current.on \value ->
 draw-heatmap = (stations) ->


### PR DESCRIPTION
因應 Heroku 勞基法，採 2 dyno 輪班制。