### PR TITLE
Update CORS server URL

### DIFF
--- a/src/air.ls
+++ b/src/air.ls
@@ -354,11 +354,7 @@ update-seven-segment = (value-string) ->
 
 function piped(url)
   url -= /^https?:\/\//
-  if (new Date).getUTCHours! < 12
-    return "https://envg0vtw-cors-dayshift.herokuapp.com/#url"
-  else
-    return "https://envg0vtw-cors-nightshift.herokuapp.com/#url"
-
+  return "https://envg0vtw-cors-dayshift.herokuapp.com/#url"
 
 #current.on \value ->
 draw-heatmap = (stations) ->


### PR DESCRIPTION
Previously, Heroku put every free dyno to sleep when it is open for more than 18 hours within 24 hours.

It is no longer true, thus the complication of day-shift/night-shift setup for CORS proxy is not required anymore.
